### PR TITLE
Authorizations

### DIFF
--- a/app/Resources/views/task/list.html.twig
+++ b/app/Resources/views/task/list.html.twig
@@ -28,9 +28,11 @@
                             {% if not task.isDone %}Marquer comme faite{% else %}Marquer non terminée{% endif %}
                         </button>
                     </form>
+                    {% if is_allowed_to_delete(task) %}
                     <form action="{{ path('task_delete', {'id' : task.id }) }}">
                         <button class="btn btn-danger btn-sm pull-right">Supprimer</button>
                     </form>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -28,5 +28,6 @@ security:
 
     access_control:
         - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/users, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/users/create, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/users, roles: ROLE_ADMIN }
         - { path: ^/, roles: ROLE_USER }

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -11,3 +11,7 @@ services:
     app.user_refresher:
         class: AppBundle\Utils\UserRefresher
         arguments: ["@security.token_storage"]
+
+    app.task_authorization_checker:
+        class: AppBundle\Utils\TaskAuthorizationChecker
+        arguments: ["@security.token_storage", "@security.authorization_checker"]

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -15,3 +15,9 @@ services:
     app.task_authorization_checker:
         class: AppBundle\Utils\TaskAuthorizationChecker
         arguments: ["@security.token_storage", "@security.authorization_checker"]
+
+    app.is_allowed_to_delete_task_extension:
+        class: AppBundle\Twig\IsAllowedToDeleteTaskExtension
+        arguments: ["@app.task_authorization_checker"]
+        tags:
+            - { name: twig.extension }

--- a/src/AppBundle/Controller/TaskController.php
+++ b/src/AppBundle/Controller/TaskController.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Controller;
 
 use AppBundle\Entity\Task;
+use AppBundle\Entity\User;
 use AppBundle\Form\TaskType;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -87,6 +88,11 @@ class TaskController extends Controller
      */
     public function deleteTaskAction(Task $task)
     {
+        $author = $task->getAuthor();
+        if (null === $author && !$this->isGranted('ROLE_ADMIN') || null !== $author && (!$this->isGranted('IS_AUTHENTICATED_FULLY') || $this->getUser()->getUsername() != $author->getUsername())) {
+            throw $this->createAccessDeniedException();
+        }
+
         $em = $this->getDoctrine()->getManager();
         $em->remove($task);
         $em->flush();

--- a/src/AppBundle/Controller/TaskController.php
+++ b/src/AppBundle/Controller/TaskController.php
@@ -88,8 +88,7 @@ class TaskController extends Controller
      */
     public function deleteTaskAction(Task $task)
     {
-        $author = $task->getAuthor();
-        if (null === $author && !$this->isGranted('ROLE_ADMIN') || null !== $author && (!$this->isGranted('IS_AUTHENTICATED_FULLY') || $this->getUser()->getUsername() != $author->getUsername())) {
+        if (!$this->get('app.task_authorization_checker')->isAllowedToDelete($task)) {
             throw $this->createAccessDeniedException();
         }
 

--- a/src/AppBundle/Controller/UserController.php
+++ b/src/AppBundle/Controller/UserController.php
@@ -54,12 +54,12 @@ class UserController extends Controller
         $form->handleRequest($request);
 
         if ($form->isValid()) {
-            $this->get('app.user_refresher')->refreshIfAuthenticated($user);
-
             $password = $this->get('security.password_encoder')->encodePassword($user, $user->getPassword());
             $user->setPassword($password);
 
             $this->getDoctrine()->getManager()->flush();
+
+            $this->get('app.user_refresher')->refreshIfAuthenticated($user);
 
             $this->addFlash('success', "L'utilisateur a bien été modifié");
 

--- a/src/AppBundle/Twig/IsAllowedToDeleteTaskExtension.php
+++ b/src/AppBundle/Twig/IsAllowedToDeleteTaskExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AppBundle\Twig;
+
+use AppBundle\Utils\TaskAuthorizationChecker;
+
+class IsAllowedToDeleteTaskExtension extends \Twig_Extension
+{
+    /**
+     * @var TaskAuthorizationChecker
+     */
+    private $taskAutorizationChecker;
+
+    public function __construct(TaskAuthorizationChecker $taskAuthorizationChecker)
+    {
+        $this->taskAutorizationChecker = $taskAuthorizationChecker;
+    }
+
+    /**
+     * @return \Twig_SimpleFunction[]
+     */
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('is_allowed_to_delete', array($this->taskAutorizationChecker, 'isAllowedToDelete'))
+        );
+    }
+}

--- a/src/AppBundle/Utils/TaskAuthorizationChecker.php
+++ b/src/AppBundle/Utils/TaskAuthorizationChecker.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace AppBundle\Utils;
+
+use AppBundle\Entity\Task;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+class TaskAuthorizationChecker
+{
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    /**
+     * @var AuthorizationCheckerInterface
+     */
+    private $authorizationChecker;
+
+    public function __construct(TokenStorageInterface $tokenStorage, AuthorizationCheckerInterface $authorizationChecker)
+    {
+        $this->tokenStorage = $tokenStorage;
+        $this->authorizationChecker = $authorizationChecker;
+    }
+
+    /**
+     * @param Task $task
+     * @return bool
+     */
+    public function isAllowedToDelete(Task $task)
+    {
+        $author = $task->getAuthor();
+        $user = $this->tokenStorage->getToken()->getUser();
+        $isAdmin = $this->authorizationChecker->isGranted('ROLE_ADMIN');
+
+        $isAuthenticated = $this->authorizationChecker->isGranted('IS_AUTHENTICATED_FULLY');
+        if (null === $author && !$isAdmin || null !== $author && (!$isAuthenticated || $user->getUsername() != $author->getUsername())) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/AppBundle/Utils/TaskAuthorizationChecker.php
+++ b/src/AppBundle/Utils/TaskAuthorizationChecker.php
@@ -33,11 +33,8 @@ class TaskAuthorizationChecker
         $author = $task->getAuthor();
         $user = $this->tokenStorage->getToken()->getUser();
         $isAdmin = $this->authorizationChecker->isGranted('ROLE_ADMIN');
-
         $isAuthenticated = $this->authorizationChecker->isGranted('IS_AUTHENTICATED_FULLY');
-        if (null === $author && !$isAdmin || null !== $author && (!$isAuthenticated || $user->getUsername() != $author->getUsername())) {
-            return false;
-        }
-        return true;
+
+        return null === $author && !$isAdmin || null !== $author && (!$isAuthenticated || $user->getUsername() != $author->getUsername());
     }
 }

--- a/src/AppBundle/Utils/TaskAuthorizationChecker.php
+++ b/src/AppBundle/Utils/TaskAuthorizationChecker.php
@@ -35,6 +35,6 @@ class TaskAuthorizationChecker
         $isAdmin = $this->authorizationChecker->isGranted('ROLE_ADMIN');
         $isAuthenticated = $this->authorizationChecker->isGranted('IS_AUTHENTICATED_FULLY');
 
-        return null === $author && !$isAdmin || null !== $author && (!$isAuthenticated || $user->getUsername() != $author->getUsername());
+        return !(null === $author && !$isAdmin || null !== $author && (!$isAuthenticated || $user->getUsername() != $author->getUsername()));
     }
 }


### PR DESCRIPTION
Access to user-management-related pages is granted to admins only.
A task can only be deleted by its author or any admin if the author is anonymous.
TaskAuthorizationChecker is a simple service for checking if the authenticated user is allowed to delete a task. It is directly called by TaskController on delete action.
Is AllowedToDeleteTaskExtension is a Twig extension allowing us to conveniently use the TaskAuthorizationChecker service from a template. It is used in tasks/list.html.twig.